### PR TITLE
Add network config reducing

### DIFF
--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -69,6 +69,8 @@ module.exports = class NetworkSession {
   }
 
   async _applyNetworkState (discoveryKey, dkeyString, { announce, lookup, flush, remember }) {
+    const self = this
+
     let states = this._networkStates.get(dkeyString)
     if (!states) {
       states = new Map()
@@ -82,28 +84,35 @@ module.exports = class NetworkSession {
       this._sessionState.addResource('@network/configuration-' + this._resources++, null, () => {
         states.delete(this._sessionState)
         if (!states.size) this._networkStates.delete(dkeyString)
+        if (!this._networker.closed) reduceAndConfigure(false)
       })
     }
 
-    let reducedAnnounce = false
-    let reducedLookup = false
-    for (const s of states.values()) {
-      reducedLookup = reducedLookup || s.lookup
-      reducedAnnounce = reducedAnnounce || s.announce
-      if (reducedLookup && reducedAnnounce) break
+    return reduceAndConfigure(true)
+
+    async function reduceAndConfigure (rejoin) {
+      let reducedAnnounce = false
+      let reducedLookup = false
+      for (const s of states.values()) {
+        reducedLookup = reducedLookup || s.lookup
+        reducedAnnounce = reducedAnnounce || s.announce
+        if (reducedLookup && reducedAnnounce) break
+      }
+      const networkProm = self._networker.configure(discoveryKey, {
+        announce: reducedAnnounce,
+        lookup: reducedLookup,
+        flush,
+        rejoin,
+        // remember/discoveryKey are passed so that they will be saved in the networker's internal configurations list.
+        remember,
+        discoveryKey
+      })
+
+      if (flush) await networkProm
+      else networkProm.catch(() => {})
+
+      return self.status(discoveryKey)
     }
-    const networkProm = this._networker.configure(discoveryKey, {
-      announce: reducedAnnounce,
-      lookup: reducedLookup,
-      flush,
-      // remember is passed so that it will be saved in the networker's internal configurations list.
-      remember
-    })
-
-    if (flush) await networkProm
-    else networkProm.catch(() => {})
-
-    return this.status(discoveryKey)
   }
 
   async configure ({ configuration: { discoveryKey, announce, lookup, remember }, flush, copyFrom, overwrite }) {
@@ -148,10 +157,7 @@ module.exports = class NetworkSession {
 
   status ({ discoveryKey }) {
     const configuration = this._networker.status(discoveryKey)
-    if (configuration) {
-      configuration.discoveryKey = discoveryKey
-      return { status: configuration}
-    }
+    if (configuration) return { status: configuration}
     return {}
   }
 

--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -81,6 +81,7 @@ module.exports = class NetworkSession {
     if (!existingResource) {
       this._sessionState.addResource('@network/configuration-' + this._resources++, null, () => {
         states.delete(this._sessionState)
+        if (!states.size) this._networkStates.delete(dkeyString)
       })
     }
 

--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -156,9 +156,8 @@ module.exports = class NetworkSession {
   }
 
   status ({ discoveryKey }) {
-    const configuration = this._networker.status(discoveryKey)
-    if (configuration) return { status: configuration}
-    return {}
+    const status = this._networker.status(discoveryKey)
+    return { status }
   }
 
   allStatuses () {

--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -10,8 +10,6 @@ module.exports = class NetworkSession {
     this._db = db
     this._noAnnounce = opts.noAnnounce
 
-    this._resources = 0
-
     const peerAddListener = (peer) => {
       this._client.network.onPeerAddNoReply({
         id: 0,
@@ -81,7 +79,7 @@ module.exports = class NetworkSession {
     states.set(this._sessionState, { announce, lookup })
     // If this is the first time this session has configured this dkey, add the GCing.
     if (!existingResource) {
-      this._sessionState.addResource('@network/configuration-' + this._resources++, null, () => {
+      this._sessionState.addResource('@network/configuration-' + dkeyString, null, () => {
         states.delete(this._sessionState)
         if (!states.size) this._networkStates.delete(dkeyString)
         if (!this._networker.closed) reduceAndConfigure(false)

--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -1,14 +1,16 @@
 const { intoPeer } = require('../common')
 
 module.exports = class NetworkSession {
-  constructor (client, sessionState, corestore, networker, db, transientConfigurations, opts = {}) {
+  constructor (client, sessionState, corestore, networker, db, networkStates, opts = {}) {
     this._client = client
     this._sessionState = sessionState
+    this._networkStates = networkStates
     this._corestore = corestore
     this._networker = networker
-    this._transientConfigurations = transientConfigurations
     this._db = db
     this._noAnnounce = opts.noAnnounce
+
+    this._resources = 0
 
     const peerAddListener = (peer) => {
       this._client.network.onPeerAddNoReply({
@@ -66,7 +68,44 @@ module.exports = class NetworkSession {
     }
   }
 
-  async configure ({ configuration: { discoveryKey, announce, lookup, remember }, resourceId, flush, copyFrom, overwrite }) {
+  async _applyNetworkState (discoveryKey, dkeyString, { announce, lookup, flush, remember }) {
+    let states = this._networkStates.get(dkeyString)
+    if (!states) {
+      states = new Map()
+      this._networkStates.set(dkeyString, states)
+    }
+
+    const existingResource = states.has(this._sessionState)
+    states.set(this._sessionState, { announce, lookup })
+    // If this is the first time this session has configured this dkey, add the GCing.
+    if (!existingResource) {
+      this._sessionState.addResource('@network/configuration-' + this._resources++, null, () => {
+        states.delete(this._sessionState)
+      })
+    }
+
+    let reducedAnnounce = false
+    let reducedLookup = false
+    for (const s of states.values()) {
+      reducedLookup = reducedLookup || s.lookup
+      reducedAnnounce = reducedAnnounce || s.announce
+      if (reducedLookup && reducedAnnounce) break
+    }
+    const networkProm = this._networker.configure(discoveryKey, {
+      announce: reducedAnnounce,
+      lookup: reducedLookup,
+      flush,
+      // remember is passed so that it will be saved in the networker's internal configurations list.
+      remember
+    })
+
+    if (flush) await networkProm
+    else networkProm.catch(() => {})
+
+    return this.status(discoveryKey)
+  }
+
+  async configure ({ configuration: { discoveryKey, announce, lookup, remember }, flush, copyFrom, overwrite }) {
     if (discoveryKey.length !== 32) throw new Error('Invalid discovery key.')
     if (copyFrom && copyFrom.length !== 32) throw new Error('Must copy from a valid discovery key.')
     const dkeyString = discoveryKey.toString('hex')
@@ -74,15 +113,15 @@ module.exports = class NetworkSession {
     const restoreTimeouts = this._setConfiguringTimeouts(discoveryKey)
     var networkProm = null
 
-    const previous = await this._getConfiguration(discoveryKey)
+    const previous = this.status(discoveryKey)
     if (previous && !overwrite) {
       if (restoreTimeouts) restoreTimeouts()
-      return
+      return previous
     }
 
     try {
       if (copyFrom) {
-        const config = await this._getConfiguration(copyFrom)
+        const config = await this.status(copyFrom)
         if (announce === undefined) announce = config && config.announce
         if (lookup === undefined) lookup = config && config.lookup
         if (remember === undefined) remember = config && config.remember
@@ -91,77 +130,33 @@ module.exports = class NetworkSession {
       const join = announce || lookup
       if (this._noAnnounce) announce = false
 
-      networkProm = this._networker.configure(discoveryKey, { announce, lookup })
+      // This will create a network configuration by aggregating settings across sessions.
+      networkProm = this._applyNetworkState(discoveryKey, dkeyString, { announce, lookup, flush, remember })
 
       const networkConfiguration = { discoveryKey, announce, lookup, remember }
       if (remember) {
         if (join) await this._db.putNetworkConfiguration(networkConfiguration)
         else await this._db.removeNetworkConfiguration(dkeyString)
       }
-      // Don't retain a list of previous entries.
-      if (previous) previous.previous = null
-      this._transientConfigurations.set(dkeyString, { ...networkConfiguration, resourceId, previous })
     } finally {
       if (restoreTimeouts) restoreTimeouts()
     }
 
-    // If remember is false, then the configuration should be reverted when the session closes.
-    if (!remember && resourceId !== undefined) {
-      this._sessionState.addResource(resourceId, null, () => this.unconfigure({ discoveryKey, resourceId }))
-    }
-
-    // If this is overwriting an old configuration, then any old session state should be deleted.
-    if (previous && previous.resourceId !== undefined && resourceId !== undefined) {
-      this._sessionState.deleteResource(previous.resourceId, true)
-    }
-
-    if (flush) {
-      return networkProm
-    }
-    // TODO: Error ignored here -- networker must emit it.
-    networkProm.catch(() => {})
-    return null
+    return networkProm
   }
 
-  async unconfigure ({ discoveryKey, resourceId }) {
-    if (discoveryKey.length !== 32) throw new Error('Invalid discovery key.')
-    const dkeyString = discoveryKey.toString('hex')
-    const currentConfig = this._transientConfigurations.get(dkeyString)
-    if (!currentConfig || currentConfig.resourceId !== resourceId) return null
-    const previous = currentConfig.previous
-    const oldConfig = {
-      discoveryKey,
-      announce: !!(previous && previous.announce),
-      lookup: !!(previous && previous.lookup),
-      remember: !!(previous && previous.remember)
+  status ({ discoveryKey }) {
+    const configuration = this._networker.status(discoveryKey)
+    if (configuration) {
+      configuration.discoveryKey = discoveryKey
+      return { status: configuration}
     }
-    await this.configure({ configuration: oldConfig, overwrite: true })
-    // If unconfigure is being run during session cleanup, the resource might already be deleted.
-    try {
-      this._sessionState.deleteResource(resourceId, true)
-    } catch (err) {}
+    return {}
   }
 
-  async _getConfiguration (discoveryKey) {
-    const dkeyString = discoveryKey.toString('hex')
-    if (this._transientConfigurations.has(dkeyString)) {
-      return this._transientConfigurations.get(dkeyString)
-    }
-    const configuration = await this._db.getNetworkConfiguration(dkeyString)
-    return configuration
-  }
-
-  async status ({ discoveryKey }) {
-    const configuration = await this._getConfiguration(discoveryKey)
-    return configuration ? { status: configuration } : {}
-  }
-
-  async allStatuses () {
-    const storedConfigurations = await this._db.listNetworkConfigurations()
-    const transientConfigurations = [...this._transientConfigurations.values()].filter(c => !c.remember)
-    return {
-      statuses: [...storedConfigurations, ...transientConfigurations]
-    }
+  allStatuses () {
+    const statuses = this._networker.allStatuses()
+    return { statuses }
   }
 
   registerExtension ({ resourceId, name }) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/hyperspace-org/hyperspace#readme",
   "dependencies": {
-    "@corestore/networker": "0.0.6",
+    "@corestore/networker": "^1.0.0",
     "@hyperspace/client": "^1.0.0",
     "@hyperspace/rpc": "^1.0.0",
     "@hyperspace/migration-tool": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@hyperswarm/dht": "^4.0.1",
     "compare": "^2.0.0",
     "hypercore-byte-stream": "^1.0.0",
-    "hyperdrive": "git+https://github.com/hypercore-protocol/hyperdrive#hyperspace-port",
+    "hyperdrive": "^10.14.1",
     "protocol-buffers": "^4.1.2",
     "random-access-memory": "^3.1.1",
     "standard": "^14.3.4",

--- a/server.js
+++ b/server.js
@@ -116,7 +116,9 @@ module.exports = class Hyperspace extends Nanoresource {
       const joinProm = this.networker.configure(config.discoveryKey, {
         announce: config.announce,
         lookup: config.lookup,
-        remember: true
+        // remember/discoveryKey are passed so that they will be saved in the networker's internal configurations list.
+        remember: true,
+        discoveryKey: config.discoveryKey
       })
       joinProm.catch(err => this.emit('swarm-error', err))
     }

--- a/server.js
+++ b/server.js
@@ -72,7 +72,7 @@ module.exports = class Hyperspace extends Nanoresource {
     }
     this._sock = getSocketName(opts.host)
     this._references = new Map()
-    this._transientNetworkConfigurations = new Map()
+    this._networkState = new Map()
   }
 
   // Nanoresource Methods
@@ -115,7 +115,8 @@ module.exports = class Hyperspace extends Nanoresource {
       if (!config.announce) continue
       const joinProm = this.networker.configure(config.discoveryKey, {
         announce: config.announce,
-        lookup: config.lookup
+        lookup: config.lookup,
+        remember: true
       })
       joinProm.catch(err => this.emit('swarm-error', err))
     }
@@ -194,7 +195,7 @@ module.exports = class Hyperspace extends Nanoresource {
     client.hyperspace.onRequest(this)
     client.corestore.onRequest(new CorestoreSession(client, sessionState, this.corestore))
     client.hypercore.onRequest(new HypercoreSession(client, sessionState))
-    client.network.onRequest(new NetworkSession(client, sessionState, this.corestore, this.networker, this.db, this._transientNetworkConfigurations, {
+    client.network.onRequest(new NetworkSession(client, sessionState, this.corestore, this.networker, this.db, this._networkState, {
       noAnnounce: this.noAnnounce
     }))
   }


### PR DESCRIPTION
Switching to a new approach to announce/lookup handing across sessions.

This PR:
1. Aggregates all announce/lookups for a given discovery key across sessions. The flag is true if any sessions have set the flag to true. 
2. Removes `unconfigure`.

TODO: Needs to have a test for multiple sessions configuring the same dkey.