### PR TITLE
Watch downloads

### DIFF
--- a/lib/sessions/hypercore.js
+++ b/lib/sessions/hypercore.js
@@ -17,6 +17,9 @@ module.exports = class HypercoreSession {
     if (this._sessionState.hasResource('@hypercore/close-' + id)) {
       this._sessionState.deleteResource('@hypercore/close-' + id)
     }
+    if (this._sessionState.hasResource('@hypercore/download-' + id)) {
+      this._sessionState.deleteResource('@hypercore/download-' + id)
+    }
     const downloadSet = this._downloads.get(id)
     if (!downloadSet) return
     for (const resourceId of downloadSet) {
@@ -207,5 +210,28 @@ module.exports = class HypercoreSession {
 
     core[LOCK] = null
     this._sessionState.deleteResource(LOCK)
+  }
+
+  async watchDownloads ({ id }) {
+    if (this._sessionState.hasResource('@hypercore/download-' + id)) {
+      return
+    }
+    const core = this._sessionState.getCore(id)
+    const downloadListener = seq => {
+      this._client.hypercore.onDownloadNoReply({
+        id,
+        seq
+      })
+    }
+    core.on('download', downloadListener)
+    this._sessionState.addResource('@hypercore/download-' + id, null, () => {
+      core.removeListener('download', downloadListener)
+    })
+  }
+
+  async unwatchDownloads ({ id }) {
+    if (this._sessionState.hasResource('@hypercore/download-' + id)) {
+      this._sessionState.deleteResource('@hypercore/download-' + id)
+    }
   }
 }


### PR DESCRIPTION
This PR allows to watch downloads. It adds `watchDownloads` and `unwatchDownloads` methods to the hypercore service. If watching downloads, `onDownload` is called towards the client for each downloaded block. Only the `seq` is transferred, not the full block. Download events are disabled by default, to skip the overhead for clients that don't need them.

This is a part of #2 and a step towards running kappa-style apps on top of hyperspace, especially for indexing sparsely synced hypercores in live mode.


Instead of adding `watchDownloads` and `unwatchDownloads` methods I was also considering of adding a single `options` method with a `OptionsRequest { bool watchDownloads  = 1 }`. When/if other session options came along that could make this more straightforward instead of adding getters and setters for each option - not sure though.