### PR TITLE
Expose bitfield

### DIFF
--- a/lib/sessions/hypercore.js
+++ b/lib/sessions/hypercore.js
@@ -80,13 +80,14 @@ module.exports = class HypercoreSession {
     })
   }
 
-  async has ({ id, seq }) {
+  async has ({ id, seq, bitfield, length }) {
     const core = this._sessionState.getCore(id)
     return new Promise((resolve, reject) => {
       core.ready(err => {
         if (err) return reject(err)
         return resolve({
-          has: core.has(seq)
+          has: core.has(seq),
+          bitfield: bitfield && core.bitfield.compress(seq, length)
         })
       })
     })

--- a/test/bitfield.js
+++ b/test/bitfield.js
@@ -1,0 +1,34 @@
+const test = require('tape')
+const { createMany } = require('./helpers/create')
+
+test('can get a bitfield', async t => {
+  const { clients, cleanup } = await createMany(2)
+
+  const client1 = clients[0]
+  const client2 = clients[1]
+  const corestore1 = client1.corestore()
+  const corestore2 = client2.corestore()
+
+  const core1 = corestore1.get()
+  await core1.ready()
+  await core1.append(Buffer.from('zero', 'utf8'))
+  await core1.append(Buffer.from('one', 'utf8'))
+  await core1.append(Buffer.from('two', 'utf8'))
+  await core1.append(Buffer.from('three', 'utf8'))
+  await client1.network.configure(core1.discoveryKey, { announce: true, lookup: true, flush: true })
+
+  const core2 = corestore2.get(core1.key)
+  await core2.ready()
+
+  await client2.network.configure(core2.discoveryKey, { announce: false, lookup: true })
+
+  await core2.get(1)
+  await core2.get(2)
+  const bitfield = await core2.getBitfield()
+  t.equal(bitfield.get(0), false)
+  t.equal(bitfield.get(1), true)
+  t.equal(bitfield.get(2), true)
+  t.equal(bitfield.get(4), false)
+  await cleanup()
+  t.end()
+})


### PR DESCRIPTION
This adds two optional fields `bitfield` and `length` to the `has` method request. If set, the response includes a run-length encoded bitfield of the downloaded blocks from `seq` for `length`.

On the client side, a new `getBitfield` method is added, that returns the decoded bitfield wrapped with [bitfield](https://github.com/fb55/bitfield) instance.

This, together with #5, should allow indexers to work reliably and efficiently on sparsely synced hypercores.